### PR TITLE
Expose the needed framebuffer info in each copy request

### DIFF
--- a/FBSimulatorControl/Framebuffer/FBSimulatorVideoStream.h
+++ b/FBSimulatorControl/Framebuffer/FBSimulatorVideoStream.h
@@ -41,6 +41,9 @@ NS_ASSUME_NONNULL_BEGIN
 + (nullable instancetype)streamWithFramebuffer:(FBFramebuffer *)framebuffer configuration:(FBVideoStreamConfiguration *)configuration logger:(id<FBControlCoreLogger>)logger;
 
 - (void)pushFrame;
+
+@property (nonatomic, copy, nullable, readwrite) NSDictionary<NSString *, id> *pixelBufferAttributes;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/FBSimulatorControl/Framebuffer/FBSimulatorVideoStream.m
+++ b/FBSimulatorControl/Framebuffer/FBSimulatorVideoStream.m
@@ -421,7 +421,6 @@ static void MinicapCompressorCallback(void *outputCallbackRefCon, void *sourceFr
 @property (nonatomic, assign, nullable, readwrite) CVPixelBufferRef pixelBuffer;
 @property (nonatomic, assign, readwrite) CFTimeInterval timeAtFirstFrame;
 @property (nonatomic, assign, readwrite) NSUInteger frameNumber;
-@property (nonatomic, copy, nullable, readwrite) NSDictionary<NSString *, id> *pixelBufferAttributes;
 @property (nonatomic, strong, nullable, readwrite) id<FBDataConsumer> consumer;
 @property (nonatomic, strong, nullable, readwrite) id<FBSimulatorVideoStreamFramePusher> framePusher;
 

--- a/proto/idb.proto
+++ b/proto/idb.proto
@@ -506,9 +506,19 @@ message FramebufferStreamRequest {
     }
 }
 
+message FramebufferInfo {
+    uint32 row_size = 1;
+    uint32 width = 2;
+    uint32 height = 3;
+    uint32 frame_size = 4;
+    string format = 5;
+}
+
 message FramebufferStreamResponse {
     string shared_memory_name = 1;
-    uint64 bytes_written = 2;
+    optional uint64 bytes_written = 2;
+    optional string error = 3;
+    optional FramebufferInfo framebuffer_info = 4;
 }
 
 message LaunchRequest {


### PR DESCRIPTION
This allows retrieving the iOS simulator framebuffer info so that we know the stride and other things when encoding. Now the response to `CopyFramebufferRequest` contains all needed info for client to porperly handle format, dimensions, padding and errors.