### PR TITLE
adjust the log verbosity in the grpc server

### DIFF
--- a/idb_companion/SwiftServer/Interceptors/LoggingInterceptor.swift
+++ b/idb_companion/SwiftServer/Interceptors/LoggingInterceptor.swift
@@ -16,10 +16,12 @@ private enum MethodStartKey: UserInfo.Key {
 final class LoggingInterceptor<Request, Response>: ServerInterceptor<Request, Response> {
 
   private let logger: FBIDBLogger
+  private let debugLogger: (any FBControlCoreLogger)?
   private let reporter: FBEventReporter
 
   init(logger: FBIDBLogger, reporter: FBEventReporter) {
     self.logger = logger
+    self.debugLogger = UserDefaults.standard.string(forKey: "-log-level") == "info" ? nil : logger.debug()
     self.reporter = reporter
   }
 
@@ -38,10 +40,10 @@ final class LoggingInterceptor<Request, Response>: ServerInterceptor<Request, Re
       reportMethodStart(methodName: methodInfo.name, in: context)
 
     case .message where methodInfo.callType == .clientStreaming || methodInfo.callType == .bidirectionalStreaming:
-      logger.debug().log("Receive frame of \(methodInfo.name)")
+      debugLogger?.log("Receive frame of \(methodInfo.name)")
 
     case .end where methodInfo.callType == .clientStreaming || methodInfo.callType == .bidirectionalStreaming:
-      logger.debug().log("Close client stream of \(methodInfo.name)")
+      debugLogger?.log("Close client stream of \(methodInfo.name)")
 
     default:
       break
@@ -85,7 +87,7 @@ final class LoggingInterceptor<Request, Response>: ServerInterceptor<Request, Re
 
     let subject: FBEventReporterSubject
     if status.isOk {
-      logger.debug().log("Success of \(methodName)")
+      debugLogger?.log("Success of \(methodName)")
       subject = FBEventReporterSubject(forSuccessfulCall: methodName, duration: duration, size: nil, arguments: [], reportNativeSwiftMethodCall: true)
     } else {
       logger.info().log("Failure of \(methodName), \(status)")

--- a/idb_companion/SwiftServer/MethodHandlers/FramebufferStreamMethodHandler.swift
+++ b/idb_companion/SwiftServer/MethodHandlers/FramebufferStreamMethodHandler.swift
@@ -57,10 +57,10 @@ struct FramebufferStreamMethodHandler {
     )
     guard let simulatorVideoStream = try await BridgeFuture.value(target.createStream(with: config)) as? FBSimulatorVideoStream else { throw GRPCStatus(code: .internalError, message: "Framebuffer stream can only be used with a simulator device") };
 
-    let targetLogger = self.targetLogger
+    let debugLogger =  UserDefaults.standard.string(forKey: "-log-level") == "info" ? nil : self.targetLogger.debug()
     let streamWriter = FIFOStreamWriter(stream: responseStream)
     let consumer = FBBlockDataConsumer.synchronousDataConsumer { data in
-      targetLogger.debug().log("Received frame data, queue size: \(copyFramebufferRequestQueue.count)")
+      debugLogger?.log("Received frame data, queue size: \(copyFramebufferRequestQueue.count)")
       guard !_finished.wrappedValue else { return }
       guard copyFramebufferRequestQueue.count != 0 else { return }
       let copyFramebufferRequest = copyFramebufferRequestQueue.removeFirst()
@@ -99,10 +99,10 @@ struct FramebufferStreamMethodHandler {
         response.error = error.localizedDescription
       }
       do {
-          targetLogger.debug().log("Sending response to copy frame request: \(serialize(response:response))")
+        debugLogger?.log("Sending response to copy frame request: \(serialize(response:response))")
         try streamWriter.send(response)
       } catch {
-        targetLogger.debug().log("Error sending response to copy frame request: \(error)")
+        debugLogger?.log("Error sending response to copy frame request: \(error)")
         targetLogger.error().log(error.localizedDescription)
         _finished.set(true)
       }
@@ -116,9 +116,9 @@ struct FramebufferStreamMethodHandler {
         case .stop:
           return
         case .copyFramebuffer(let copyFramebufferRequest):
-          targetLogger.debug().log("Received copy frame request, shared memory name: \(copyFramebufferRequest.sharedMemoryName)")
+          debugLogger?.log("Received copy frame request, shared memory name: \(copyFramebufferRequest.sharedMemoryName)")
           simulatorVideoStream.writeQueue.async {
-            targetLogger.debug().log("Executing copy frame frequest, shared memory name: \(copyFramebufferRequest.sharedMemoryName), queue size: \(copyFramebufferRequestQueue.count)")
+            debugLogger?.log("Executing copy frame frequest, shared memory name: \(copyFramebufferRequest.sharedMemoryName), queue size: \(copyFramebufferRequestQueue.count)")
             copyFramebufferRequestQueue.append(CopyFramebufferRequest(
               sharedMemoryName: copyFramebufferRequest.sharedMemoryName,
               sharedMemoryLength: copyFramebufferRequest.sharedMemoryLength


### PR DESCRIPTION
Since the loggers don't cap the max log level (see FBControlCoreLogger) and there are several types of implementations lets just use same heuristics as in `main` when doing debug logging in the grpc server handlers, so that the maximum log level is honoured.