### PR TITLE
Strip the SIMCTL_CHILD_ prefix from env var keys

### DIFF
--- a/idb_companion/main.m
+++ b/idb_companion/main.m
@@ -219,9 +219,10 @@ static FBFuture<FBFuture<NSNull *> *> *BootFuture(NSString *udid, NSUserDefaults
       }
       NSMutableDictionary *bootEnvironment = [NSMutableDictionary new];
       NSDictionary *environment = NSProcessInfo.processInfo.environment;
+      NSString *simctlChildPrefix = @"SIMCTL_CHILD_";
       for (NSString *key in environment) {
-        if ([key hasPrefix:@"SIMCTL_CHILD_"]) {
-            bootEnvironment[key] = environment[key];
+        if ([key hasPrefix:simctlChildPrefix]) {
+            bootEnvironment[[key substringFromIndex:simctlChildPrefix.length]] = environment[key];
         }
       }
       FBSimulatorBootConfiguration *config = [[FBSimulatorBootConfiguration alloc] initWithOptions:options environment:bootEnvironment];


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to `idb` here: https://github.com/facebook/idb/blob/main/.github/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

(Write your motivation here.)

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos!)

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/idb, and link to your PR here.)
