### PR TITLE
Honour log level when enabling/disabling debug logging in core simula…

### DIFF
--- a/FBControlCore/Utility/FBControlCoreLogger+OSLog.m
+++ b/FBControlCore/Utility/FBControlCoreLogger+OSLog.m
@@ -93,6 +93,11 @@ static const char *LoggerSubsystem = "com.facebook.fbcontrolcore";
   return self;
 }
 
+- (BOOL)isLogLevelAtLeast:(FBControlCoreLogLevel)logLevel
+{
+  return self.level >= logLevel;
+}
+
 @end
 
 #endif

--- a/FBControlCore/Utility/FBControlCoreLogger.h
+++ b/FBControlCore/Utility/FBControlCoreLogger.h
@@ -76,6 +76,15 @@ typedef NS_ENUM(NSUInteger, FBControlCoreLogLevel) {
  */
 - (id<FBControlCoreLogger>)withDateFormatEnabled:(BOOL)enabled;
 
+/**
+ Tests if log level is at least the log level provided via the argument, useful for composite loggers that
+ would return FBControlCoreLogLevelMultiple via the level accessor.
+ 
+ @param logLevel the log level to test
+ @return boolean indicating if the log level is equal or higher than the one provided via the argument
+ */
+- (BOOL)isLogLevelAtLeast:(FBControlCoreLogLevel)logLevel;
+
 #pragma mark Properties
 
 /**

--- a/FBControlCore/Utility/FBControlCoreLogger.m
+++ b/FBControlCore/Utility/FBControlCoreLogger.m
@@ -75,6 +75,11 @@
   return self;
 }
 
+- (BOOL)isLogLevelAtLeast:(FBControlCoreLogLevel)logLevel
+{
+  return self.level >= logLevel;
+}
+
 @end
 
 @implementation FBCompositeLogger
@@ -136,6 +141,15 @@
 - (id<FBControlCoreLogger>)withDateFormatEnabled:(BOOL)dateFormat
 {
   return [self loggerByApplyingSelector:_cmd object:@(dateFormat)];
+}
+- (BOOL)isLogLevelAtLeast:(FBControlCoreLogLevel)logLevel
+{
+  for (id<FBControlCoreLogger> logger in self.loggers) {
+    if ([logger isLogLevelAtLeast:logLevel]) {
+        return YES;
+    }
+  }
+  return NO;
 }
 
 - (NSString *)name
@@ -262,6 +276,11 @@
     [dateFormatter setDateFormat:@"yyyy-MM-dd HH:mm:ss.SSSZZZ"];
   }
   return [[self.class alloc] initWithConsumer:self.consumer name:self.name dateFormatter:dateFormatter];
+}
+
+- (BOOL)isLogLevelAtLeast:(FBControlCoreLogLevel)logLevel
+{
+  return self.level >= logLevel;
 }
 
 @end

--- a/FBSimulatorControl/Utility/FBSimulatorControlFrameworkLoader.m
+++ b/FBSimulatorControl/Utility/FBSimulatorControlFrameworkLoader.m
@@ -81,7 +81,7 @@ static void FBSimulatorControl_SimLogHandler(int level, const char *function, in
     // Hook the default handler to call us instead.
     [FBSimulatorControlFrameworkLoader_Essential setInternalLogHandler];
     // Set CoreSimulator Logging since it is now loaded.
-    [FBSimulatorControlFrameworkLoader_Essential setCoreSimulatorLoggingEnabled:(logger.level >= FBControlCoreLogLevelDebug)];
+    [FBSimulatorControlFrameworkLoader_Essential setCoreSimulatorLoggingEnabled:[logger isLogLevelAtLeast:FBControlCoreLogLevelDebug]];
   }
   return loaded;
 }

--- a/XCTestBootstrap/Utility/FBXCTestLogger.m
+++ b/XCTestBootstrap/Utility/FBXCTestLogger.m
@@ -146,6 +146,11 @@ static NSString *const xctoolOutputLogDirectoryEnv = @"XCTOOL_TEST_ENV_FB_LOG_DI
     logDirectory:self.logDirectory];
 }
 
+- (BOOL)isLogLevelAtLeast:(FBControlCoreLogLevel)logLevel
+{
+  return self.baseLogger.level >= logLevel;
+}
+
 - (NSString *)name
 {
   return self.baseLogger.name;


### PR DESCRIPTION
…tor service

Currently a composite logger that returns log level "multiple" will toggle the debug logs in core simulator which causes a lot of spam in ~/Library/Logs/CoreSimulator/CoreSimulator.log

<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to `idb` here: https://github.com/facebook/idb/blob/main/.github/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

(Write your motivation here.)

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos!)

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/idb, and link to your PR here.)
